### PR TITLE
[fix] add windows DeviceIndependentBitmap clipboard type

### DIFF
--- a/src/paster.ts
+++ b/src/paster.ts
@@ -483,7 +483,7 @@ class Paster {
          } else if(platform == "win32") {
             for(var i = 0; i < type_array.length; i++) {
                 var type = type_array[i];
-                if(type == "PNG" || type=="Bitmap") {
+                if(type == "PNG" || type=="Bitmap" || type=="DeviceIndependentBitmap") {
                     content_type = ClipboardType.Image;
                     break;
                 } else if(type == "UnicodeText" || type == "Text" || type=="HTML Format") {


### PR DESCRIPTION
On windows 10 when pasting from e.g. Paint the clipboard content type returned by the powershell script is `DeviceIndependentBitmap`.