### PR TITLE
Prefix relative image paths with './'

### DIFF
--- a/src/paster.ts
+++ b/src/paster.ts
@@ -265,6 +265,8 @@ class Paster {
 
         // relative will be add backslash characters so need to replace '\' to '/' here.
         let imageFilePath = this.encodePath(path.relative(path.dirname(docPath), pasteImgContext.targetFile.fsPath));
+        // Some markdown renderers (like the one used by VuePress) do not display images when the relative path does not include './'
+        imageFilePath = `./${imageFilePath}`;
 
         if (languageId === 'markdown') {
             let imgTag = pasteImgContext.imgTag;


### PR DESCRIPTION
Some markdown engines (like the one used by the VuePress framework) do not display images with relative paths if there is no './' prefix in the path.
This PR adds such a prefix to all images pasted in the markdown format.