### PR TITLE
Add HTML support for windows

### DIFF
--- a/res/win32_get_clipboard_text_html.ps1
+++ b/res/win32_get_clipboard_text_html.ps1
@@ -7,6 +7,6 @@ foreach ($property in $properties) {
     $metadata[$property.Groups[1].Value] = $property.Groups[2].Value
 }
 
-$text = [System.Text.Encoding]::UTF8.GetString([System.Text.Encoding]::UTF8.GetBytes($content)[$metadata["StartFragment"]..$($metadata["EndFragment"] - 1)])
+$text = [System.Text.Encoding]::UTF8.GetString([System.Text.Encoding]::Default.GetBytes($content)[$metadata["StartFragment"]..$($metadata["EndFragment"] - 1)])
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 [Console]::WriteLine($text)

--- a/res/win32_get_clipboard_text_html.ps1
+++ b/res/win32_get_clipboard_text_html.ps1
@@ -1,4 +1,12 @@
 add-type -an system.windows.forms
 $content = [System.Windows.Forms.Clipboard]::GetText([System.Windows.Forms.TextDataFormat]::Html)
+$metadata = @{}
+$properties = [regex]::Matches($content, "^([A-Za-z]*):(.*?)[\r\n$]", [System.Text.RegularExpressions.RegexOptions]::Multiline)
+
+foreach ($property in $properties) {
+    $metadata[$property.Groups[1].Value] = $property.Groups[2].Value
+}
+
+$text = [System.Text.Encoding]::UTF8.GetString([System.Text.Encoding]::UTF8.GetBytes($content)[$metadata["StartFragment"]..$($metadata["EndFragment"] - 1)])
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-[Console]::WriteLine($content)
+[Console]::WriteLine($text)

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -586,7 +586,9 @@ class Paster {
                 if(type == "PNG" || type=="Bitmap") {
                     content_type = ClipboardType.Image;
                     break;
-                } else if(type == "UnicodeText" || type == "Text" || type=="HTML Format") {
+                } else if(type=="HTML Format") {
+                    content_type = ClipboardType.Html;
+                } else if(type == "UnicodeText" || type == "Text") {
                     content_type = ClipboardType.Text;
                     break;
                 }


### PR DESCRIPTION
At time of writing, HTML text pasted on windows isn't formatted.
This PR will add support for pasting HTML content on windows with formatting enabled.

In order to provide said support, the `res/win32_get_clipboard_text_html.ps1` file was adjusted to extract the html source code from the clipboard as described in Microsoft's docs which can be found on the following page: https://docs.microsoft.com/en-us/windows/win32/dataxchg/html-clipboard-format

Merging this PR will fix #44
Furthermore, this PR is related to #17 (bullet lists in PowerPoint still don't work)

I tried pasting content from HTML pages (such as https://gist.github.com/rxaviers/7360908) and Word successfully.
Also, I pasted content from PowerPoint successfully, however - some features such as bullet lists didn't work while bold, italic etc. text worked properly.

I'd be delighted to see this PR being part of the upcoming version!
Thanks for your great work