### PR TITLE
Fix #65 wslpath returning newlines

### DIFF
--- a/src/paster.ts
+++ b/src/paster.ts
@@ -36,7 +36,9 @@ class PasteImageContext {
 async function wslSafe(path: string) {
   if (getCurrentPlatform() != "wsl") return path;
   await runCommand("touch", [path]);
-  return runCommand("wslpath", ["-m", path]);
+  const wslPath = await runCommand("wslpath", ["-m", path])
+  // Sometimes the result from wslpath contains newlines, and creates havok in powershell later
+  return wslPath.trim();
 }
 
 /**


### PR DESCRIPTION
In #65 I discovered that on my system that `wslpath` was returning trailing newlines, this fix trims those newlines.