### PR TITLE
Temporary macOS download image fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-paste-image",
-  "version": "0.18.5",
+  "version": "0.18.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-paste-image",
-      "version": "0.18.5",
+      "version": "0.18.6",
       "license": "(MIT)",
       "dependencies": {
         "@vscode/vscode-languagedetection": "^1.0.21",

--- a/res/scripts/mac_get_clipboard_text_plain.applescript
+++ b/res/scripts/mac_get_clipboard_text_plain.applescript
@@ -1,0 +1,2 @@
+set clipboardText to (the clipboard as text)
+do shell script "echo " & quoted form of clipboardText

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -21,6 +21,7 @@ enum ClipboardType {
   Html = 0,
   Text,
   Image,
+  Apple,
 }
 
 class PasteImageContext {
@@ -120,6 +121,7 @@ class Paster {
       case ClipboardType.Image:
         Paster.pasteImage();
         break;
+      case ClipboardType.Apple:
       case ClipboardType.Unknown:
         // Probably missing script to support type detection
         const textContent = clipboard.readSync();
@@ -142,6 +144,7 @@ class Paster {
     Logger.log("Clipboard Type:", ctx_type);
     switch (ctx_type) {
       case ClipboardType.Html:
+      case ClipboardType.Apple:
       case ClipboardType.Text:
         const text = await this.pasteTextPlain();
         if (text) {
@@ -504,7 +507,7 @@ class Paster {
     const script = {
       win32: "win32_get_clipboard_text_plain.ps1",
       linux: "linux_get_clipboard_text_plain.sh",
-      darwin: null,
+      darwin: "mac_get_clipboard_text_plain.applescript",
       wsl: "win32_get_clipboard_text_plain.ps1",
       win10: "win32_get_clipboard_text_plain.ps1",
     };
@@ -763,6 +766,10 @@ class Paster {
     };
 
     try {
+      let platform = getCurrentPlatform();
+      if (platform === "darwin") {
+        return ClipboardType.Apple;
+      }
       let data = await this.runScript(script, []);
       Logger.log("getClipboardContentType", data);
       if (data == "no xclip") {


### PR DESCRIPTION
macOS download image from clipboard URL previously wouldn't work. Added `mac_get_clipboard_text_plain.applescript` to get URL from clipboard.  
Created new "temporary" ClipboardType called `ClipboardType.Apple`. Not the best solution but works fine for now as a quick fix.  
I see the requirements of the extension requires `pbpaste` for macOS but I do not see it implemented anywhere. I assume it's for further macOS integration to achieve download image.