### PR TITLE
Revert "Temporary macOS download image fix"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-paste-image",
-  "version": "0.18.6",
+  "version": "0.18.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-paste-image",
-      "version": "0.18.6",
+      "version": "0.18.5",
       "license": "(MIT)",
       "dependencies": {
         "@vscode/vscode-languagedetection": "^1.0.21",

--- a/res/scripts/mac_get_clipboard_text_plain.applescript
+++ b/res/scripts/mac_get_clipboard_text_plain.applescript
@@ -1,2 +1,0 @@
-set clipboardText to (the clipboard as text)
-do shell script "echo " & quoted form of clipboardText

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -21,7 +21,6 @@ enum ClipboardType {
   Html = 0,
   Text,
   Image,
-  Apple,
 }
 
 class PasteImageContext {
@@ -121,7 +120,6 @@ class Paster {
       case ClipboardType.Image:
         Paster.pasteImage();
         break;
-      case ClipboardType.Apple:
       case ClipboardType.Unknown:
         // Probably missing script to support type detection
         const textContent = clipboard.readSync();
@@ -144,7 +142,6 @@ class Paster {
     Logger.log("Clipboard Type:", ctx_type);
     switch (ctx_type) {
       case ClipboardType.Html:
-      case ClipboardType.Apple:
       case ClipboardType.Text:
         const text = await this.pasteTextPlain();
         if (text) {
@@ -507,7 +504,7 @@ class Paster {
     const script = {
       win32: "win32_get_clipboard_text_plain.ps1",
       linux: "linux_get_clipboard_text_plain.sh",
-      darwin: "mac_get_clipboard_text_plain.applescript",
+      darwin: null,
       wsl: "win32_get_clipboard_text_plain.ps1",
       win10: "win32_get_clipboard_text_plain.ps1",
     };
@@ -766,10 +763,6 @@ class Paster {
     };
 
     try {
-      let platform = getCurrentPlatform();
-      if (platform === "darwin") {
-        return ClipboardType.Apple;
-      }
       let data = await this.runScript(script, []);
       Logger.log("getClipboardContentType", data);
       if (data == "no xclip") {


### PR DESCRIPTION
Reverts telesoho/vscode-markdown-paste-image#81
I have to revert it, the new  `ClipboardType.Apple` will confuse other people. We need a `mac_clipboard_content_type.applescipt` script to get right clipboard type first.