### PR TITLE
feat: add enableHtmlConverter & enableRulesForHtml

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,18 @@
           "default": false,
           "description": "Enable/disable showing confirm box while paste image."
         },
+        "MarkdownPaste.enableHtmlConverter": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Enable/disable converting html to markdown."
+        },
+        "MarkdownPaste.enableRulesForHtml": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": true,
+          "description": "Enable/disable using rules after converting html to markdown."
+        },
         "MarkdownPaste.enableImgTag": {
           "type": "boolean",
           "scope": "resource",

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -104,13 +104,29 @@ class Paster {
   public static async pasteText() {
     const ctx_type = await this.getClipboardContentType();
 
+    let enableHtmlConverter = this.getConfig().enableHtmlConverter;
+    let enableRulesForHtml = this.getConfig().enableRulesForHtml;
+
     Logger.log("Clipboard Type:", ctx_type);
     switch (ctx_type) {
       case ClipboardType.Html:
-        const html = await this.pasteTextHtml();
-        Logger.log(html);
-        const markdown = toMarkdown(html);
-        Paster.writeToEditor(markdown);
+        if (enableHtmlConverter) {
+          const html = await this.pasteTextHtml();
+          Logger.log(html);
+          const markdown = toMarkdown(html);
+          if (enableRulesForHtml) {
+            let newMarkdown = Paster.parse(markdown);
+            Paster.writeToEditor(newMarkdown);
+          } else {
+            Paster.writeToEditor(markdown);
+          }
+        } else {
+          const text = await this.pasteTextPlain();
+          if (text) {
+            let newContent = Paster.parse(text);
+            Paster.writeToEditor(newContent);
+          }
+        }
         break;
       case ClipboardType.Text:
         const text = await this.pasteTextPlain();


### PR DESCRIPTION
Add two config about html to markdown.

- "enableHtmlConverter": Enable/disable converting html to markdown (if disable, using plainText instead).
- "enableRulesForHtml": Enable/disable using rules after converting html to markdown.