### PR TITLE
feat: add applyAllRules config

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,12 @@
           "default": false,
           "description": "Enable/disable showing confirm box while paste image."
         },
+        "MarkdownPaste.applyAllRules": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "description": "If true, it will apply all rules to the same text orderly, instead only the first applicable one."
+        },
         "MarkdownPaste.enableImgTag": {
           "type": "boolean",
           "scope": "resource",

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -463,15 +463,24 @@ class Paster {
     let editor = vscode.window.activeTextEditor;
     let languageId = editor.document.languageId;
     let rules = this.get_rules(languageId);
+    let applyAllRules = this.getConfig().applyAllRules;
+    let isApplicable = false;
     for (const rule of rules) {
       const re = new RegExp(rule.regex, rule.options);
       const reps = rule.replace;
       if (re.test(content)) {
-        const newstr = content.replace(re, reps);
-        return newstr;
+        content = content.replace(re, reps);
+        if (!applyAllRules) {
+          return content;
+        }
+        isApplicable = true;
       }
     }
-    return null;
+    if (isApplicable) {
+      return content;
+    } else {
+      return null;
+    }
   }
 
   private static parse(content) {


### PR DESCRIPTION
Add a new config: `applyAllRules`, default to be false.

If true, it will apply all rules to the same text orderly, instead only the first applicable one.

I hope that I can add one single space between all chinese characters and letters, and convert punctuation automatically, like `测试test测试。` to `测试 test 测试.`

![image](https://user-images.githubusercontent.com/34951714/221581536-20d0b091-98c2-4409-b822-0acd1317c357.png)

So I need to add many rules and hope that they can be replaced using all rules.

But the extension only applies one applicable rule instead all rules. So I add the config `applyAllRules`.