### PR TITLE
Md header style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-markdown-paste-image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-markdown-paste-image",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "(MIT)",
       "dependencies": {
         "@vscode/vscode-languagedetection": "^1.0.22",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,16 @@
           "default": true,
           "description": "Enable/disable converting html to markdown."
         },
+        "MarkdownPaste.headerStyle": {
+          "type": "string",
+          "scope": "resource",
+          "enum": [
+            "setext",
+            "atx"
+          ],
+          "default": "setext",
+          "description": "Use setext or atx style markdown headers."
+        },
         "MarkdownPaste.enableRulesForHtml": {
           "type": "boolean",
           "scope": "resource",

--- a/src/paster.ts
+++ b/src/paster.ts
@@ -46,6 +46,7 @@ class Paster {
 
     let enableHtmlConverter = Paster.getConfig().enableHtmlConverter;
     let enableRulesForHtml = Paster.getConfig().enableRulesForHtml;
+    let headerStyle = Paster.getConfig().headerStyle;
 
     Logger.log("Clipboard Type:", ctx_type);
     switch (ctx_type) {
@@ -53,7 +54,7 @@ class Paster {
         if (enableHtmlConverter) {
           const html = await cb.getTextHtml();
           Logger.log(html);
-          const markdown = toMarkdown(html);
+          const markdown = toMarkdown(html, headerStyle);
           if (enableRulesForHtml) {
             let newMarkdown = Paster.parse(markdown);
             Paster.writeToEditor(newMarkdown);

--- a/src/toMarkdown.ts
+++ b/src/toMarkdown.ts
@@ -28,7 +28,7 @@ function cell(content, node) {
   return prefix + content + " " + suffix;
 }
 
-function toMarkdown(content) {
+function toMarkdown(content, headingStyle) {
   // http://pandoc.org/README.html#pandocs-markdown
   const pandoc = [
     // {
@@ -254,7 +254,7 @@ function toMarkdown(content) {
   };
 
   var TurndownService = require("turndown");
-  var turndownService = new TurndownService();
+  var turndownService = new TurndownService({ headingStyle });
   Object.entries(pandoc).forEach(([key, value]) => {
     turndownService.addRule(key, value);
   });


### PR DESCRIPTION
Thanks for this really useful package!

I prefer the `atx` style markdown headers over the `setext` type, so I added a configuration option to switch between them. Wanted to send this little feature upstream!